### PR TITLE
chore: rename to "Push for Github"

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Github Push</string>
+    <string name="app_name">Push for Github</string>
 </resources>

--- a/android/fastlane/metadata/android/en-US/title.txt
+++ b/android/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Github Push
+Push for Github

--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
   "name": "GithubPushNotificationsMobile",
-  "displayName": "Github Push"
+  "displayName": "Push for Github"
 }

--- a/ios/GithubPushNotificationsMobile/Info.plist
+++ b/ios/GithubPushNotificationsMobile/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Github Push</string>
+	<string>Push for Github</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -3,7 +3,7 @@ apple_id ENV['FASTLANE_USER'] || 'nicodz993@me.com' # Your Apple email address
 team_id 'BJJKE72WM4'
 team_name 'Nicolas Gebauer'
 itc_team_id '118110410'
-# app_name 'Github Push'
+# app_name 'Push for Github'
 
 # For more information about the Appfile, see:
 #     https://docs.fastlane.tools/advanced/#appfile

--- a/src/App.js
+++ b/src/App.js
@@ -99,7 +99,7 @@ export default class App extends React.Component {
     'Notification',
     `Open notification url\n${url}`,
     [
-      { text: 'Cancel', onPress: () => {}, style: 'cancel' },
+      { text: 'Cancel', onPress: () => { }, style: 'cancel' },
       {
         text: 'Open',
         onPress: () => Linking.canOpenURL(url).then(canOpen => canOpen && Linking.openURL(url))
@@ -110,7 +110,7 @@ export default class App extends React.Component {
 
   render() {
     const { loading, token, username, avatarUrl, loginError, notificationsError } = this.state
-    if (loading) return <LoadingView text="Loading account"/>
+    if (loading) return <LoadingView text="Loading account" />
     if (!loading && !token) {
       return (
         <View style={styles.loginBackground}>
@@ -137,7 +137,7 @@ export default class App extends React.Component {
             </TouchableOpacity>
           </View>
           <View style={styles.container}>
-            <Image style={styles.avatar} source={{ uri: avatarUrl }}/>
+            <Image style={styles.avatar} source={{ uri: avatarUrl }} />
             <Text style={styles.username}>{username}</Text>
             {!notificationsError && <Text style={styles.subtitle}>Notifications active</Text>}
             {notificationsError &&
@@ -148,7 +148,7 @@ export default class App extends React.Component {
                 </TouchableOpacity>
               </>
             }
-            <Text style={styles.data}>{`Github Push v${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`}</Text>
+            <Text style={styles.data}>{`Push for Github v${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`}</Text>
           </View>
         </View>
       </Notifications>


### PR DESCRIPTION
Rename the app from "Github Push" to "Push for Github" in accordance with Github's approved use of their name