### PR TITLE
chore(ci): improve iOS build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,11 @@ jobs:
       - *save-gemfile-cache-mac
       - *set-env-api-url
       - *set-env-gcm-send-id
-      - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - *restore-cocoapods-cache
+      - run:
+          name: Download cocoapods
+          command: if [[ ! -e ~/.cocoapods ]]; then curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; fi
+      - *save-cocoapods-cache
       - run: pod install
       - *fastlane-build-ci
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ yarn-cache-key: &yarn-cache-key yarn-v8-{{ checksum "yarn.lock" }}
 yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }}
 gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
 gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
-xcode-cache-key: &xcode-cache-key xcode-v8
 cocapods-cache-key: &cocoapods-cache-key cocoapods-v9
 
 ### Configs ###
@@ -98,10 +97,6 @@ restore-gemfile-cache-mac: &restore-gemfile-cache-mac
   restore_cache:
     key: *gemfile-cache-key-mac
 
-restore-xcode-cache: &restore-xcode-cache
-  restore_cache:
-    key: *xcode-cache-key
-
 restore-cocoapods-cache: &restore-cocoapods-cache
   restore_cache:
     key: *cocoapods-cache-key
@@ -147,12 +142,6 @@ save-gemfile-cache-mac: &save-gemfile-cache-mac
     key: *gemfile-cache-key-mac
     paths:
       - vendor/bundle
-
-save-xcode-cache: &save-xcode-cache
-  save_cache:
-    key: *xcode-cache-key
-    paths:
-      - ~/Library/Developer/Xcode/DerivedData
 
 save-cocoapods-cache: &save-cocoapods-cache
   save_cache:
@@ -227,9 +216,7 @@ jobs:
           command: if [[ ! -e ~/.cocoapods/repos ]]; then curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; fi
       - *save-cocoapods-cache
       - run: pod install
-      - *restore-xcode-cache
       - *fastlane-build-ci
-      - *save-xcode-cache
       - store_artifacts:
           path: GithubPushNotificationsMobile.ipa
           destination: ./GithubPushNotificationsMobile.ipa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,23 +68,23 @@ fastlane-beta-ci: &fastlane-beta-ci
 
 restore-yarn-cache: &restore-yarn-cache
   restore_cache:
-    key: yarn-v6-{{ checksum "yarn.lock" }}-{{ arch }}
+    key: yarn-v6-{{ checksum "yarn.lock" }}
 
 restore-node-cache: &restore-node-cache
   restore_cache:
-    key: node-v6-{{ checksum "package.json" }}-{{ arch }}
+    key: node-v6-{{ checksum "package.json" }}
 
-restore-yarn-cache-ios: &restore-yarn-cache-ios
+restore-yarn-cache-mobile: &restore-yarn-cache-mobile
   restore_cache:
-    key: yarn-v6-{{ checksum "../yarn.lock" }}-{{ arch }}
+    key: yarn-v6-{{ checksum "../yarn.lock" }}
 
-restore-node-cache-ios: &restore-node-cache-ios
+restore-node-cache-mobile: &restore-node-cache-mobile
   restore_cache:
-    key: node-v6-{{ checksum "../package.json" }}-{{ arch }}
+    key: node-v6-{{ checksum "../package.json" }}
 
 restore-gemfile-cache: &restore-gemfile-cache
   restore_cache:
-    key: bundle-v6-{{ checksum "Gemfile.lock" }}-{{ arch }}
+    key: bundle-v6-{{ checksum "Gemfile.lock" }}
 
 yarn-install: &yarn-install
   run: yarn
@@ -94,31 +94,31 @@ bundle-install: &bundle-install
 
 save-yarn-cache: &save-yarn-cache
   save_cache:
-    key: yarn-v1-{{ checksum "yarn.lock" }}-{{ arch }}
+    key: yarn-v1-{{ checksum "yarn.lock" }}
     paths:
       - ~/.cache/yarn
 
 save-node-cache: &save-node-cache
   save_cache:
-    key: node-v1-{{ checksum "package.json" }}-{{ arch }}
+    key: node-v1-{{ checksum "package.json" }}
     paths:
       - node_modules
 
-save-yarn-cache-ios: &save-yarn-cache-ios
+save-yarn-cache-mobile: &save-yarn-cache-mobile
   save_cache:
-    key: yarn-v1-{{ checksum "../yarn.lock" }}-{{ arch }}
+    key: yarn-v1-{{ checksum "../yarn.lock" }}
     paths:
       - ~/.cache/yarn
 
-save-node-cache-ios: &save-node-cache-ios
+save-node-cache-mobile: &save-node-cache-mobile
   save_cache:
-    key: node-v1-{{ checksum "../package.json" }}-{{ arch }}
+    key: node-v1-{{ checksum "../package.json" }}
     paths:
       - node_modules
 
 save-gemfile-cache: &save-gemfile-cache
   save_cache:
-    key: bundle-v2-{{ checksum "Gemfile.lock" }}-{{ arch }}
+    key: bundle-v2-{{ checksum "Gemfile.lock" }}
     paths:
       - vendor/bundle
 
@@ -171,13 +171,13 @@ jobs:
     steps:
       - *checkout-mobile
       - *set-ios-ruby-version
-      - *restore-yarn-cache-ios
-      - *restore-node-cache-ios
+      - *restore-yarn-cache-mobile
+      - *restore-node-cache-mobile
       # not using a workspace here as Node and Yarn versions differ
       # between our macOS executor image and the Docker containers above
       - *yarn-install
-      - *save-yarn-cache-ios
-      - *save-node-cache-ios
+      - *save-yarn-cache-mobile
+      - *save-node-cache-mobile
       - *restore-gemfile-cache
       - *bundle-install
       - *save-gemfile-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }
 gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
 gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
 xcode-cache-key: &xcode-cache-key xcode-v8
-cocapods-cache-key: &cocoapods-cache-key cocoapods-v9
 
 ### Configs ###
 
@@ -102,10 +101,6 @@ restore-xcode-cache: &restore-xcode-cache
   restore_cache:
     key: *xcode-cache-key
 
-restore-cocoapods-cache: &restore-cocoapods-cache
-  restore_cache:
-    key: *cocoapods-cache-key
-
 yarn-install: &yarn-install
   run: yarn
 
@@ -153,12 +148,6 @@ save-xcode-cache: &save-xcode-cache
     key: *xcode-cache-key
     paths:
       - ~/Library/Developer/Xcode/DerivedData
-
-save-cocoapods-cache: &save-cocoapods-cache
-  save_cache:
-    key: *cocoapods-cache-key
-    paths:
-      - ~/.cocoapods/repos
 
 ### Jobs ###
 
@@ -221,11 +210,9 @@ jobs:
       - *save-gemfile-cache-mac
       - *set-env-api-url
       - *set-env-gcm-send-id
-      - *restore-cocoapods-cache
       - run:
           name: Download cocoapods
-          command: if [[ ! -e ~/.cocoapods/repos ]]; then curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; fi
-      - *save-cocoapods-cache
+          command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
       - run: pod install
       - *restore-xcode-cache
       - *fastlane-build-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }
 gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
 gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
 xcode-cache-key: &xcode-cache-key xcode-v8
+cocapods-cache-key: &cocoapods-cache-key cocoapods-v9
 
 ### Configs ###
 
@@ -101,6 +102,10 @@ restore-xcode-cache: &restore-xcode-cache
   restore_cache:
     key: *xcode-cache-key
 
+restore-cocoapods-cache: &restore-cocoapods-cache
+  restore_cache:
+    key: *cocoapods-cache-key
+
 yarn-install: &yarn-install
   run: yarn
 
@@ -148,6 +153,12 @@ save-xcode-cache: &save-xcode-cache
     key: *xcode-cache-key
     paths:
       - ~/Library/Developer/Xcode/DerivedData
+
+save-cocoapods-cache: &save-cocoapods-cache
+  save_cache:
+    key: *cocoapods-cache-key
+    paths:
+      - ~/.cocoapods/repos
 
 ### Jobs ###
 
@@ -210,9 +221,11 @@ jobs:
       - *save-gemfile-cache-mac
       - *set-env-api-url
       - *set-env-gcm-send-id
+      - *restore-cocoapods-cache
       - run:
           name: Download cocoapods
-          command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+          command: if [[ ! -e ~/.cocoapods/repos ]]; then curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; fi
+      - *save-cocoapods-cache
       - run: pod install
       - *restore-xcode-cache
       - *fastlane-build-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }
 gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
 gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
 xcode-cache-key: &xcode-cache-key xcode-v8
-cocapods-cache-key: &cocoapods-cache-key cocoapods-v8
+cocapods-cache-key: &cocoapods-cache-key cocoapods-v9
 
 ### Configs ###
 
@@ -158,7 +158,7 @@ save-cocoapods-cache: &save-cocoapods-cache
   save_cache:
     key: *cocoapods-cache-key
     paths:
-      - ~/.cocoapods
+      - ~/.cocoapods/repos
 
 ### Jobs ###
 
@@ -224,7 +224,7 @@ jobs:
       - *restore-cocoapods-cache
       - run:
           name: Download cocoapods
-          command: if [[ ! -e ~/.cocoapods ]]; then curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; fi
+          command: if [[ ! -e ~/.cocoapods/repos ]]; then curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; fi
       - *save-cocoapods-cache
       - run: pod install
       - *fastlane-build-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,9 @@ jobs:
           command: if [[ ! -e ~/.cocoapods/repos ]]; then curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf; fi
       - *save-cocoapods-cache
       - run: pod install
+      - *restore-xcode-cache
       - *fastlane-build-ci
+      - *save-xcode-cache
       - store_artifacts:
           path: GithubPushNotificationsMobile.ipa
           destination: ./GithubPushNotificationsMobile.ipa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ yarn-cache-key: &yarn-cache-key yarn-v8-{{ checksum "yarn.lock" }}
 yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }}
 gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
 gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
+xcode-cache-key: &xcode-cache-key xcode-v8
 
 ### Configs ###
 
@@ -96,6 +97,10 @@ restore-gemfile-cache-mac: &restore-gemfile-cache-mac
   restore_cache:
     key: *gemfile-cache-key-mac
 
+restore-xcode-cache: &restore-xcode-cache
+  restore_cache:
+    key: *xcode-cache-key
+
 yarn-install: &yarn-install
   run: yarn
 
@@ -124,7 +129,7 @@ save-yarn-cache-mac: &save-yarn-cache-mac
   save_cache:
     key: *yarn-cache-key-mac
     paths:
-      - /Users/distiller/Library/Caches/Yarn
+      - ~/Library/Caches/Yarn
 
 save-gemfile-cache: &save-gemfile-cache
   save_cache:
@@ -137,6 +142,12 @@ save-gemfile-cache-mac: &save-gemfile-cache-mac
     key: *gemfile-cache-key-mac
     paths:
       - vendor/bundle
+
+save-xcode-cache: &save-xcode-cache
+  save_cache:
+    key: *xcode-cache-key
+    paths:
+      - ~/Library/Developer/Xcode/DerivedData
 
 ### Jobs ###
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ node-cache-key-mac: &node-cache-key-mac node-v7-mac-{{ checksum "../package.json
 yarn-cache-key: &yarn-cache-key yarn-v7-{{ checksum "yarn.lock" }}
 yarn-cache-key-mac: &yarn-cache-key-mac yarn-v7-mac-{{ checksum "../yarn.lock" }}
 gemfile-cache-key: &gemfile-cache-key bundle-v7-{{ checksum "Gemfile.lock" }}
+gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v7-mac-{{ checksum "Gemfile.lock" }}
 
 ### Configs ###
 
@@ -79,17 +80,21 @@ restore-node-cache: &restore-node-cache
   restore_cache:
     key: *node-cache-key
 
-restore-yarn-cache-mobile: &restore-yarn-cache-mobile
+restore-yarn-cache-mac: &restore-yarn-cache-mac
   restore_cache:
     key: *yarn-cache-key-mac
 
-restore-node-cache-mobile: &restore-node-cache-mobile
+restore-node-cache-mac: &restore-node-cache-mac
   restore_cache:
     key: *node-cache-key-mac
 
 restore-gemfile-cache: &restore-gemfile-cache
   restore_cache:
     key: *gemfile-cache-key
+
+restore-gemfile-cache-mac: &restore-gemfile-cache-mac
+  restore_cache:
+    key: *gemfile-cache-key-mac
 
 yarn-install: &yarn-install
   run: yarn
@@ -103,7 +108,7 @@ save-node-cache: &save-node-cache
     paths:
       - node_modules
 
-save-node-cache-mobile: &save-node-cache-mobile
+save-node-cache-mac: &save-node-cache-mac
   save_cache:
     key: *node-cache-key-mac
     paths:
@@ -115,7 +120,7 @@ save-yarn-cache: &save-yarn-cache
     paths:
       - ~/.cache/yarn
 
-save-yarn-cache-mobile: &save-yarn-cache-mobile
+save-yarn-cache-mac: &save-yarn-cache-mac
   save_cache:
     key: *yarn-cache-key-mac
     paths:
@@ -124,6 +129,12 @@ save-yarn-cache-mobile: &save-yarn-cache-mobile
 save-gemfile-cache: &save-gemfile-cache
   save_cache:
     key: *gemfile-cache-key
+    paths:
+      - vendor/bundle
+
+save-gemfile-cache-mac: &save-gemfile-cache-mac
+  save_cache:
+    key: *gemfile-cache-key-mac
     paths:
       - vendor/bundle
 
@@ -176,16 +187,16 @@ jobs:
     steps:
       - *checkout-mobile
       - *set-ios-ruby-version
-      - *restore-yarn-cache-mobile
-      - *restore-node-cache-mobile
+      - *restore-yarn-cache-mac
+      - *restore-node-cache-mac
       # not using a workspace here as Node and Yarn versions differ
       # between our macOS executor image and the Docker containers above
       - *yarn-install
-      - *save-yarn-cache-mobile
-      - *save-node-cache-mobile
-      - *restore-gemfile-cache
+      - *save-yarn-cache-mac
+      - *save-node-cache-mac
+      - *restore-gemfile-cache-mac
       - *bundle-install
-      - *save-gemfile-cache
+      - *save-gemfile-cache-mac
       - *set-env-api-url
       - *set-env-gcm-send-id
       - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
@@ -223,9 +234,9 @@ jobs:
       - *attach-mobile
       - *attach-ios
       - *set-ios-ruby-version
-      - *restore-gemfile-cache
+      - *restore-gemfile-cache-mac
       - *bundle-install
-      - *save-gemfile-cache
+      - *save-gemfile-cache-mac
       - *fastlane-beta-ci
 
   deploy-android:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,13 +77,13 @@ restore-yarn-cache: &restore-yarn-cache
   restore_cache:
     key: *yarn-cache-key
 
-restore-node-cache: &restore-node-cache
-  restore_cache:
-    key: *node-cache-key
-
 restore-yarn-cache-mac: &restore-yarn-cache-mac
   restore_cache:
     key: *yarn-cache-key-mac
+
+restore-node-cache: &restore-node-cache
+  restore_cache:
+    key: *node-cache-key
 
 restore-node-cache-mac: &restore-node-cache-mac
   restore_cache:
@@ -107,18 +107,6 @@ yarn-install: &yarn-install
 bundle-install: &bundle-install
   run: bundle install --path vendor/bundle
 
-save-node-cache: &save-node-cache
-  save_cache:
-    key: *node-cache-key
-    paths:
-      - node_modules
-
-save-node-cache-mac: &save-node-cache-mac
-  save_cache:
-    key: *node-cache-key-mac
-    paths:
-      - ../node_modules
-
 save-yarn-cache: &save-yarn-cache
   save_cache:
     key: *yarn-cache-key
@@ -130,6 +118,18 @@ save-yarn-cache-mac: &save-yarn-cache-mac
     key: *yarn-cache-key-mac
     paths:
       - ~/Library/Caches/Yarn
+
+save-node-cache: &save-node-cache
+  save_cache:
+    key: *node-cache-key
+    paths:
+      - node_modules
+
+save-node-cache-mac: &save-node-cache-mac
+  save_cache:
+    key: *node-cache-key-mac
+    paths:
+      - ../node_modules
 
 save-gemfile-cache: &save-gemfile-cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ version: 2
 project-folder: &project-folder ~/push-for-github-mobile
 android-folder: &android-folder ~/push-for-github-mobile/android
 ios-folder: &ios-folder ~/push-for-github-mobile/ios
-node-cache-key: &node-cache-key node-v8-{{ checksum "package.json" }}
-node-cache-key-mac: &node-cache-key-mac node-v8-mac-{{ checksum "../package.json" }}
-yarn-cache-key: &yarn-cache-key yarn-v8-{{ checksum "yarn.lock" }}
-yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }}
-gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
-gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
-cocapods-cache-key: &cocoapods-cache-key cocoapods-v9
+node-cache-key: &node-cache-key node-v9-{{ checksum "package.json" }}
+node-cache-key-mac: &node-cache-key-mac node-v9-mac-{{ checksum "../package.json" }}
+yarn-cache-key: &yarn-cache-key yarn-v9-{{ checksum "yarn.lock" }}
+yarn-cache-key-mac: &yarn-cache-key-mac yarn-v9-mac-{{ checksum "../yarn.lock" }}
+gemfile-cache-key: &gemfile-cache-key bundle-v9-{{ checksum "Gemfile.lock" }}
+gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v9-mac-{{ checksum "Gemfile.lock" }}
+cocapods-cache-key: &cocoapods-cache-key cocoapods-v9-{{ checksum "Podfile.lock" }}
 
 ### Configs ###
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,9 @@ project-folder: &project-folder ~/push-for-github-mobile
 android-folder: &android-folder ~/push-for-github-mobile/android
 ios-folder: &ios-folder ~/push-for-github-mobile/ios
 node-cache-key: &node-cache-key node-v7-{{ checksum "package.json" }}
-node-cache-key-mobile: &node-cache-key-mobile node-v7-{{ checksum "../package.json" }}
+node-cache-key-mac: &node-cache-key-mac node-v7-mac-{{ checksum "../package.json" }}
 yarn-cache-key: &yarn-cache-key yarn-v7-{{ checksum "yarn.lock" }}
-yarn-cache-key-mobile: &yarn-cache-key-mobile yarn-v7-{{ checksum "../yarn.lock" }}
+yarn-cache-key-mac: &yarn-cache-key-mac yarn-v7-mac-{{ checksum "../yarn.lock" }}
 gemfile-cache-key: &gemfile-cache-key bundle-v7-{{ checksum "Gemfile.lock" }}
 
 ### Configs ###
@@ -81,11 +81,11 @@ restore-node-cache: &restore-node-cache
 
 restore-yarn-cache-mobile: &restore-yarn-cache-mobile
   restore_cache:
-    key: *yarn-cache-key-mobile
+    key: *yarn-cache-key-mac
 
 restore-node-cache-mobile: &restore-node-cache-mobile
   restore_cache:
-    key: *node-cache-key-mobile
+    key: *node-cache-key-mac
 
 restore-gemfile-cache: &restore-gemfile-cache
   restore_cache:
@@ -105,7 +105,7 @@ save-node-cache: &save-node-cache
 
 save-node-cache-mobile: &save-node-cache-mobile
   save_cache:
-    key: *node-cache-key-mobile
+    key: *node-cache-key-mac
     paths:
       - node_modules
 
@@ -117,7 +117,7 @@ save-yarn-cache: &save-yarn-cache
 
 save-yarn-cache-mobile: &save-yarn-cache-mobile
   save_cache:
-    key: *yarn-cache-key-mobile
+    key: *yarn-cache-key-mac
     paths:
       - ~/.cache/yarn
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }
 gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
 gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
 xcode-cache-key: &xcode-cache-key xcode-v8
+cocapods-cache-key: &cocoapods-cache-key cocoapods-v8
 
 ### Configs ###
 
@@ -101,6 +102,10 @@ restore-xcode-cache: &restore-xcode-cache
   restore_cache:
     key: *xcode-cache-key
 
+restore-cocoapods-cache: &restore-cocoapods-cache
+  restore_cache:
+    key: *cocoapods-cache-key
+
 yarn-install: &yarn-install
   run: yarn
 
@@ -148,6 +153,12 @@ save-xcode-cache: &save-xcode-cache
     key: *xcode-cache-key
     paths:
       - ~/Library/Developer/Xcode/DerivedData
+
+save-cocoapods-cache: &save-cocoapods-cache
+  save_cache:
+    key: *cocoapods-cache-key
+    paths:
+      - ~/.cocoapods
 
 ### Jobs ###
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,12 @@ version: 2
 project-folder: &project-folder ~/push-for-github-mobile
 android-folder: &android-folder ~/push-for-github-mobile/android
 ios-folder: &ios-folder ~/push-for-github-mobile/ios
-node-cache-key: &node-cache-key node-v7-{{ checksum "package.json" }}
-node-cache-key-mac: &node-cache-key-mac node-v7-mac-{{ checksum "../package.json" }}
-yarn-cache-key: &yarn-cache-key yarn-v7-{{ checksum "yarn.lock" }}
-yarn-cache-key-mac: &yarn-cache-key-mac yarn-v7-mac-{{ checksum "../yarn.lock" }}
-gemfile-cache-key: &gemfile-cache-key bundle-v7-{{ checksum "Gemfile.lock" }}
-gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v7-mac-{{ checksum "Gemfile.lock" }}
+node-cache-key: &node-cache-key node-v8-{{ checksum "package.json" }}
+node-cache-key-mac: &node-cache-key-mac node-v8-mac-{{ checksum "../package.json" }}
+yarn-cache-key: &yarn-cache-key yarn-v8-{{ checksum "yarn.lock" }}
+yarn-cache-key-mac: &yarn-cache-key-mac yarn-v8-mac-{{ checksum "../yarn.lock" }}
+gemfile-cache-key: &gemfile-cache-key bundle-v8-{{ checksum "Gemfile.lock" }}
+gemfile-cache-key-mac: &gemfile-cache-key-mac bundle-v8-mac-{{ checksum "Gemfile.lock" }}
 
 ### Configs ###
 
@@ -112,7 +112,7 @@ save-node-cache-mac: &save-node-cache-mac
   save_cache:
     key: *node-cache-key-mac
     paths:
-      - node_modules
+      - ../node_modules
 
 save-yarn-cache: &save-yarn-cache
   save_cache:
@@ -124,7 +124,7 @@ save-yarn-cache-mac: &save-yarn-cache-mac
   save_cache:
     key: *yarn-cache-key-mac
     paths:
-      - ~/.cache/yarn
+      - /Users/distiller/Library/Caches/Yarn
 
 save-gemfile-cache: &save-gemfile-cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ version: 2
 project-folder: &project-folder ~/push-for-github-mobile
 android-folder: &android-folder ~/push-for-github-mobile/android
 ios-folder: &ios-folder ~/push-for-github-mobile/ios
+node-cache-key: &node-cache-key node-v7-{{ checksum "package.json" }}
+node-cache-key-mobile: &node-cache-key-mobile node-v7-{{ checksum "../package.json" }}
+yarn-cache-key: &yarn-cache-key yarn-v7-{{ checksum "yarn.lock" }}
+yarn-cache-key-mobile: &yarn-cache-key-mobile yarn-v7-{{ checksum "../yarn.lock" }}
+gemfile-cache-key: &gemfile-cache-key bundle-v7-{{ checksum "Gemfile.lock" }}
 
 ### Configs ###
 
@@ -68,23 +73,23 @@ fastlane-beta-ci: &fastlane-beta-ci
 
 restore-yarn-cache: &restore-yarn-cache
   restore_cache:
-    key: yarn-v6-{{ checksum "yarn.lock" }}
+    key: *yarn-cache-key
 
 restore-node-cache: &restore-node-cache
   restore_cache:
-    key: node-v6-{{ checksum "package.json" }}
+    key: *node-cache-key
 
 restore-yarn-cache-mobile: &restore-yarn-cache-mobile
   restore_cache:
-    key: yarn-v6-{{ checksum "../yarn.lock" }}
+    key: *yarn-cache-key-mobile
 
 restore-node-cache-mobile: &restore-node-cache-mobile
   restore_cache:
-    key: node-v6-{{ checksum "../package.json" }}
+    key: *node-cache-key-mobile
 
 restore-gemfile-cache: &restore-gemfile-cache
   restore_cache:
-    key: bundle-v6-{{ checksum "Gemfile.lock" }}
+    key: *gemfile-cache-key
 
 yarn-install: &yarn-install
   run: yarn
@@ -92,33 +97,33 @@ yarn-install: &yarn-install
 bundle-install: &bundle-install
   run: bundle install --path vendor/bundle
 
-save-yarn-cache: &save-yarn-cache
-  save_cache:
-    key: yarn-v1-{{ checksum "yarn.lock" }}
-    paths:
-      - ~/.cache/yarn
-
 save-node-cache: &save-node-cache
   save_cache:
-    key: node-v1-{{ checksum "package.json" }}
+    key: *node-cache-key
     paths:
       - node_modules
-
-save-yarn-cache-mobile: &save-yarn-cache-mobile
-  save_cache:
-    key: yarn-v1-{{ checksum "../yarn.lock" }}
-    paths:
-      - ~/.cache/yarn
 
 save-node-cache-mobile: &save-node-cache-mobile
   save_cache:
-    key: node-v1-{{ checksum "../package.json" }}
+    key: *node-cache-key-mobile
     paths:
       - node_modules
 
+save-yarn-cache: &save-yarn-cache
+  save_cache:
+    key: *yarn-cache-key
+    paths:
+      - ~/.cache/yarn
+
+save-yarn-cache-mobile: &save-yarn-cache-mobile
+  save_cache:
+    key: *yarn-cache-key-mobile
+    paths:
+      - ~/.cache/yarn
+
 save-gemfile-cache: &save-gemfile-cache
   save_cache:
-    key: bundle-v2-{{ checksum "Gemfile.lock" }}
+    key: *gemfile-cache-key
     paths:
       - vendor/bundle
 


### PR DESCRIPTION
Just some caching of modules to improve build time

As stated in this links

https://medium.com/@bitrise/60-faster-builds-force-xcode-to-use-caching-on-bitrise-af8979ca39a6

https://medium.com/@bitrise/60-faster-builds-force-xcode-to-use-caching-on-bitrise-af8979ca39a6

Xcode archive always uses a clean state, so there is no way to reduce the build time now